### PR TITLE
Pointcloud to laserpointcloud

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(catkin REQUIRED COMPONENTS
 
 catkin_package(
   INCLUDE_DIRS include
-  LIBRARIES laserscan_to_pointcloud pointcloud_to_laserscan
+  LIBRARIES laserscan_to_pointcloud pointcloud_to_laserscan pointcloud_to_laserpointcloud
   CATKIN_DEPENDS laser_geometry message_filters nodelet roscpp sensor_msgs tf2 tf2_ros tf2_sensor_msgs
 )
 
@@ -35,11 +35,19 @@ target_link_libraries(pointcloud_to_laserscan ${catkin_LIBRARIES})
 add_executable(pointcloud_to_laserscan_node src/pointcloud_to_laserscan_node.cpp)
 target_link_libraries(pointcloud_to_laserscan_node pointcloud_to_laserscan ${catkin_LIBRARIES})
 
+add_library(pointcloud_to_laserpointcloud src/pointcloud_to_laserpointcloud_nodelet.cpp)
+target_link_libraries(pointcloud_to_laserpointcloud ${catkin_LIBRARIES})
+
+add_executable(pointcloud_to_laserpointcloud_node src/pointcloud_to_laserpointcloud_node.cpp)
+target_link_libraries(pointcloud_to_laserpointcloud_node pointcloud_to_laserpointcloud ${catkin_LIBRARIES})
+
 install(TARGETS
   laserscan_to_pointcloud
   laserscan_to_pointcloud_node
   pointcloud_to_laserscan
   pointcloud_to_laserscan_node
+  pointcloud_to_laserpointcloud
+  pointcloud_to_laserpointcloud_node
 	RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 	LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
 	ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})

--- a/include/pointcloud_to_laserscan/pointcloud_to_laserpointcloud.h
+++ b/include/pointcloud_to_laserscan/pointcloud_to_laserpointcloud.h
@@ -1,0 +1,97 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2010-2012, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ */
+
+/*
+ * Author: Paul Bovbel
+ */
+
+#ifndef POINTCLOUD_TO_LASERSCAN_POINTCLOUD_TO_LASERPOINTCLOUD_NODELET_H
+#define POINTCLOUD_TO_LASERSCAN_POINTCLOUD_TO_LASERPOINTCLOUD_NODELET_H
+
+#include <boost/thread/mutex.hpp>
+#include <message_filters/subscriber.h>
+#include <nodelet/nodelet.h>
+#include <ros/ros.h>
+#include <sensor_msgs/PointCloud2.h>
+#include <string>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/message_filter.h>
+#include <tf2_ros/transform_listener.h>
+
+namespace pointcloud_to_laserscan
+{
+typedef tf2_ros::MessageFilter<sensor_msgs::PointCloud2> MessageFilter;
+/**
+* Class to process incoming pointclouds into laserscans. Some initial code was pulled from the defunct turtlebot
+* pointcloud_to_laserscan implementation.
+*/
+class PointCloudToLaserPointCloudNodelet : public nodelet::Nodelet
+{
+public:
+  PointCloudToLaserPointCloudNodelet();
+
+private:
+  virtual void onInit();
+
+  void cloudCb(const sensor_msgs::PointCloud2ConstPtr& cloud_msg);
+  void failureCb(const sensor_msgs::PointCloud2ConstPtr& cloud_msg,
+                 tf2_ros::filter_failure_reasons::FilterFailureReason reason);
+
+  void connectCb();
+
+  void disconnectCb();
+
+  ros::NodeHandle nh_, private_nh_;
+  ros::Publisher pub_;
+  boost::mutex connect_mutex_;
+
+  boost::shared_ptr<tf2_ros::Buffer> tf2_;
+  boost::shared_ptr<tf2_ros::TransformListener> tf2_listener_;
+  message_filters::Subscriber<sensor_msgs::PointCloud2> sub_;
+  boost::shared_ptr<MessageFilter> message_filter_;
+
+  // ROS Parameters
+  unsigned int input_queue_size_;
+  std::string target_frame_;
+  double tolerance_;
+  double min_height_, max_height_, angle_min_, angle_max_, angle_increment_, scan_time_, range_min_, range_max_, min_intensity_;
+  bool use_inf_;
+  double inf_epsilon_;
+};
+
+}  // namespace pointcloud_to_laserscan
+
+#endif  // POINTCLOUD_TO_LASERSCAN_POINTCLOUD_TO_LASERPOINTCLOUD_NODELET_H

--- a/include/pointcloud_to_laserscan/pointcloud_to_laserpointcloud_nodelet.h
+++ b/include/pointcloud_to_laserscan/pointcloud_to_laserpointcloud_nodelet.h
@@ -46,10 +46,12 @@
 #include <nodelet/nodelet.h>
 #include <ros/ros.h>
 #include <sensor_msgs/PointCloud2.h>
+#include <sensor_msgs/LaserScan.h>
 #include <string>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/message_filter.h>
 #include <tf2_ros/transform_listener.h>
+#include <laser_geometry/laser_geometry.h>
 
 namespace pointcloud_to_laserscan
 {
@@ -82,6 +84,8 @@ private:
   boost::shared_ptr<tf2_ros::TransformListener> tf2_listener_;
   message_filters::Subscriber<sensor_msgs::PointCloud2> sub_;
   boost::shared_ptr<MessageFilter> message_filter_;
+
+  laser_geometry::LaserProjection projector_;
 
   // ROS Parameters
   unsigned int input_queue_size_;

--- a/include/pointcloud_to_laserscan/pointcloud_to_laserpointcloud_nodelet.h
+++ b/include/pointcloud_to_laserscan/pointcloud_to_laserpointcloud_nodelet.h
@@ -78,6 +78,7 @@ private:
 
   ros::NodeHandle nh_, private_nh_;
   ros::Publisher pub_;
+  ros::Publisher pub_laserscan_;
   boost::mutex connect_mutex_;
 
   boost::shared_ptr<tf2_ros::Buffer> tf2_;
@@ -89,7 +90,7 @@ private:
 
   // ROS Parameters
   unsigned int input_queue_size_;
-  std::string target_frame_;
+  std::string target_frame_, target_laserscan_frame_;
   double tolerance_;
   double min_height_, max_height_, angle_min_, angle_max_, angle_increment_, scan_time_, range_min_, range_max_, min_intensity_;
   bool use_inf_;

--- a/nodelets.xml
+++ b/nodelets.xml
@@ -21,3 +21,16 @@
   </class>
 
 </library>
+
+<library path="lib/libpointcloud_to_laserpointcloud">
+
+  <class name="pointcloud_to_laserpointcloud/pointcloud_to_laserpointcloud_nodelet"
+	 type="pointcloud_to_laserpointcloud::PointCloudToLaserPointCloudNodelet"
+	 base_class_type="nodelet::Nodelet">
+    <description>
+      Nodelet to convert sensor_msgs/PointCloud2 to sensor_msgs/PointCloud2 containing the same points that a sensor_msgs/LaserScan would contain.
+      Useful to change sensor origin without affecting the data, given that sensor_msgs/LaserScan uses angular ranges and resolutions to reconstruct data.
+    </description>
+  </class>
+
+</library>

--- a/nodelets.xml
+++ b/nodelets.xml
@@ -24,8 +24,8 @@
 
 <library path="lib/libpointcloud_to_laserpointcloud">
 
-  <class name="pointcloud_to_laserpointcloud/pointcloud_to_laserpointcloud_nodelet"
-	 type="pointcloud_to_laserpointcloud::PointCloudToLaserPointCloudNodelet"
+  <class name="pointcloud_to_laserscan/pointcloud_to_laserpointcloud_nodelet"
+	 type="pointcloud_to_laserscan::PointCloudToLaserPointCloudNodelet"
 	 base_class_type="nodelet::Nodelet">
     <description>
       Nodelet to convert sensor_msgs/PointCloud2 to sensor_msgs/PointCloud2 containing the same points that a sensor_msgs/LaserScan would contain.

--- a/src/pointcloud_to_laserpointcloud_node.cpp
+++ b/src/pointcloud_to_laserpointcloud_node.cpp
@@ -1,0 +1,69 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2010-2012, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ */
+
+/*
+ * Author: Paul Bovbel
+ */
+
+#include <nodelet/loader.h>
+#include <ros/ros.h>
+#include <string>
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "pointcloud_to_laserpointcloud_node");
+  ros::NodeHandle private_nh("~");
+  int concurrency_level;
+  private_nh.param<int>("concurrency_level", concurrency_level, 0);
+
+  nodelet::Loader nodelet;
+  nodelet::M_string remap(ros::names::getRemappings());
+  nodelet::V_string nargv;
+  std::string nodelet_name = ros::this_node::getName();
+  nodelet.load(nodelet_name, "pointcloud_to_laserscan/pointcloud_to_laserpointcloud_nodelet", remap, nargv);
+
+  boost::shared_ptr<ros::MultiThreadedSpinner> spinner;
+  if (concurrency_level)
+  {
+    spinner.reset(new ros::MultiThreadedSpinner(concurrency_level));
+  }
+  else
+  {
+    spinner.reset(new ros::MultiThreadedSpinner());
+  }
+  spinner->spin();
+  return 0;
+}

--- a/src/pointcloud_to_laserpointcloud_nodelet.cpp
+++ b/src/pointcloud_to_laserpointcloud_nodelet.cpp
@@ -56,6 +56,7 @@ void PointCloudToLaserPointCloudNodelet::onInit()
   boost::mutex::scoped_lock lock(connect_mutex_);
   private_nh_ = getPrivateNodeHandle();
 
+  private_nh_.param<std::string>("target_laserscan_frame", target_laserscan_frame_, "");
   private_nh_.param<std::string>("target_frame", target_frame_, "");
   private_nh_.param<double>("transform_tolerance", tolerance_, 0.01);
   private_nh_.param<double>("min_height", min_height_, std::numeric_limits<double>::min());
@@ -96,6 +97,7 @@ void PointCloudToLaserPointCloudNodelet::onInit()
   }
 
   // if pointcloud target frame specified, we need to filter by transform availability
+  // TODO: target_laserscan_frame_
   if (!target_frame_.empty())
   {
     tf2_.reset(new tf2_ros::Buffer());
@@ -111,12 +113,14 @@ void PointCloudToLaserPointCloudNodelet::onInit()
 
   pub_ = nh_.advertise<sensor_msgs::PointCloud2>("cloud", 10, boost::bind(&PointCloudToLaserPointCloudNodelet::connectCb, this),
                                               boost::bind(&PointCloudToLaserPointCloudNodelet::disconnectCb, this));
+  pub_laserscan_ = nh_.advertise<sensor_msgs::LaserScan>("laserscan", 10, boost::bind(&PointCloudToLaserPointCloudNodelet::connectCb, this),
+                                              boost::bind(&PointCloudToLaserPointCloudNodelet::disconnectCb, this));
 }
 
 void PointCloudToLaserPointCloudNodelet::connectCb()
 {
   boost::mutex::scoped_lock lock(connect_mutex_);
-  if (pub_.getNumSubscribers() > 0 && sub_.getSubscriber().getNumPublishers() == 0)
+  if ((pub_.getNumSubscribers() > 0 || pub_laserscan_.getNumSubscribers() > 0) && sub_.getSubscriber().getNumPublishers() == 0)
   {
     NODELET_INFO("Got a subscriber to scan, starting subscriber to pointcloud");
     sub_.subscribe(nh_, "cloud_in", input_queue_size_);
@@ -126,7 +130,7 @@ void PointCloudToLaserPointCloudNodelet::connectCb()
 void PointCloudToLaserPointCloudNodelet::disconnectCb()
 {
   boost::mutex::scoped_lock lock(connect_mutex_);
-  if (pub_.getNumSubscribers() == 0)
+  if (pub_.getNumSubscribers() == 0 || pub_laserscan_.getNumSubscribers() == 0)
   {
     NODELET_INFO("No subscibers to scan, shutting down subscriber to pointcloud");
     sub_.unsubscribe();
@@ -147,6 +151,11 @@ void PointCloudToLaserPointCloudNodelet::cloudCb(const sensor_msgs::PointCloud2C
   // build laserscan laser_output using the same frame as the original cloud
   sensor_msgs::LaserScan laser_output;
   laser_output.header = cloud_msg->header;
+  if (!target_laserscan_frame_.empty())
+  {
+    output.header.frame_id = target_laserscan_frame_;
+  }
+
   laser_output.angle_min = angle_min_;
   laser_output.angle_max = angle_max_;
   laser_output.angle_increment = angle_increment_;
@@ -170,7 +179,27 @@ void PointCloudToLaserPointCloudNodelet::cloudCb(const sensor_msgs::PointCloud2C
   laser_output.intensities.assign(ranges_size, 0);
 
   sensor_msgs::PointCloud2ConstPtr cloud_out;
-  cloud_out = cloud_msg;
+  sensor_msgs::PointCloud2Ptr cloud;
+
+  // Transform cloud if necessary
+  if (!(output.header.frame_id == cloud_msg->header.frame_id))
+  {
+    try
+    {
+      cloud.reset(new sensor_msgs::PointCloud2);
+      tf2_->transform(*cloud_msg, *cloud, target_laserscan_frame_, ros::Duration(tolerance_));
+      cloud_out = cloud;
+    }
+    catch (tf2::TransformException& ex)
+    {
+      NODELET_ERROR_STREAM("Transform failure: " << ex.what());
+      return;
+    }
+  }
+  else
+  {
+    cloud_out = cloud_msg;
+  }
 
   // Iterate through pointcloud
   for (sensor_msgs::PointCloud2ConstIterator<float> iter_x(*cloud_out, "x"), iter_y(*cloud_out, "y"),
@@ -240,6 +269,7 @@ void PointCloudToLaserPointCloudNodelet::cloudCb(const sensor_msgs::PointCloud2C
     }
   }
   pub_.publish(*scan_cloud);
+  pub_laserscan_.publish(laser_output);
 }
 }  // namespace pointcloud_to_laserscan
 

--- a/src/pointcloud_to_laserpointcloud_nodelet.cpp
+++ b/src/pointcloud_to_laserpointcloud_nodelet.cpp
@@ -153,7 +153,7 @@ void PointCloudToLaserPointCloudNodelet::cloudCb(const sensor_msgs::PointCloud2C
   laser_output.header = cloud_msg->header;
   if (!target_laserscan_frame_.empty())
   {
-    output.header.frame_id = target_laserscan_frame_;
+    laser_output.header.frame_id = target_laserscan_frame_;
   }
 
   laser_output.angle_min = angle_min_;
@@ -182,7 +182,7 @@ void PointCloudToLaserPointCloudNodelet::cloudCb(const sensor_msgs::PointCloud2C
   sensor_msgs::PointCloud2Ptr cloud;
 
   // Transform cloud if necessary
-  if (!(output.header.frame_id == cloud_msg->header.frame_id))
+  if (!(laser_output.header.frame_id == cloud_msg->header.frame_id))
   {
     try
     {

--- a/src/pointcloud_to_laserpointcloud_nodelet.cpp
+++ b/src/pointcloud_to_laserpointcloud_nodelet.cpp
@@ -130,7 +130,7 @@ void PointCloudToLaserPointCloudNodelet::connectCb()
 void PointCloudToLaserPointCloudNodelet::disconnectCb()
 {
   boost::mutex::scoped_lock lock(connect_mutex_);
-  if (pub_.getNumSubscribers() == 0 || pub_laserscan_.getNumSubscribers() == 0)
+  if (pub_.getNumSubscribers() == 0 && pub_laserscan_.getNumSubscribers() == 0)
   {
     NODELET_INFO("No subscibers to scan, shutting down subscriber to pointcloud");
     sub_.unsubscribe();

--- a/src/pointcloud_to_laserpointcloud_nodelet.cpp
+++ b/src/pointcloud_to_laserpointcloud_nodelet.cpp
@@ -1,0 +1,246 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2010-2012, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ */
+
+/*
+ * Author: Paul Bovbel
+ */
+
+#include <limits>
+#include <pluginlib/class_list_macros.h>
+#include <pointcloud_to_laserscan/pointcloud_to_laserpointcloud_nodelet.h>
+#include <sensor_msgs/point_cloud2_iterator.h>
+#include <string>
+#include <tf2_sensor_msgs/tf2_sensor_msgs.h>
+
+namespace pointcloud_to_laserscan
+{
+PointCloudToLaserPointCloudNodelet::PointCloudToLaserPointCloudNodelet()
+{
+}
+
+void PointCloudToLaserPointCloudNodelet::onInit()
+{
+  boost::mutex::scoped_lock lock(connect_mutex_);
+  private_nh_ = getPrivateNodeHandle();
+
+  private_nh_.param<std::string>("target_frame", target_frame_, "");
+  private_nh_.param<double>("transform_tolerance", tolerance_, 0.01);
+  private_nh_.param<double>("min_height", min_height_, std::numeric_limits<double>::min());
+  private_nh_.param<double>("max_height", max_height_, std::numeric_limits<double>::max());
+
+  private_nh_.param<double>("angle_min", angle_min_, -M_PI);
+  private_nh_.param<double>("angle_max", angle_max_, M_PI);
+  private_nh_.param<double>("angle_increment", angle_increment_, M_PI / 180.0);
+  private_nh_.param<double>("scan_time", scan_time_, 1.0 / 30.0);
+  private_nh_.param<double>("range_min", range_min_, 0.0);
+  private_nh_.param<double>("range_max", range_max_, std::numeric_limits<double>::max());
+  private_nh_.param<double>("inf_epsilon", inf_epsilon_, 1.0);
+
+  private_nh_.param<double>("min_intensity", min_intensity_, 0.0);
+
+  int concurrency_level;
+  private_nh_.param<int>("concurrency_level", concurrency_level, 1);
+  private_nh_.param<bool>("use_inf", use_inf_, false);
+
+  // Check if explicitly single threaded, otherwise, let nodelet manager dictate thread pool size
+  if (concurrency_level == 1)
+  {
+    nh_ = getNodeHandle();
+  }
+  else
+  {
+    nh_ = getMTNodeHandle();
+  }
+
+  // Only queue one pointcloud per running thread
+  if (concurrency_level > 0)
+  {
+    input_queue_size_ = concurrency_level;
+  }
+  else
+  {
+    input_queue_size_ = boost::thread::hardware_concurrency();
+  }
+
+  // if pointcloud target frame specified, we need to filter by transform availability
+  if (!target_frame_.empty())
+  {
+    tf2_.reset(new tf2_ros::Buffer());
+    tf2_listener_.reset(new tf2_ros::TransformListener(*tf2_));
+    message_filter_.reset(new MessageFilter(sub_, *tf2_, target_frame_, input_queue_size_, nh_));
+    message_filter_->registerCallback(boost::bind(&PointCloudToLaserPointCloudNodelet::cloudCb, this, _1));
+    message_filter_->registerFailureCallback(boost::bind(&PointCloudToLaserPointCloudNodelet::failureCb, this, _1, _2));
+  }
+  else  // otherwise setup direct subscription
+  {
+    sub_.registerCallback(boost::bind(&PointCloudToLaserPointCloudNodelet::cloudCb, this, _1));
+  }
+
+  pub_ = nh_.advertise<sensor_msgs::PointCloud2>("cloud", 10, boost::bind(&PointCloudToLaserPointCloudNodelet::connectCb, this),
+                                              boost::bind(&PointCloudToLaserPointCloudNodelet::disconnectCb, this));
+}
+
+void PointCloudToLaserPointCloudNodelet::connectCb()
+{
+  boost::mutex::scoped_lock lock(connect_mutex_);
+  if (pub_.getNumSubscribers() > 0 && sub_.getSubscriber().getNumPublishers() == 0)
+  {
+    NODELET_INFO("Got a subscriber to scan, starting subscriber to pointcloud");
+    sub_.subscribe(nh_, "cloud_in", input_queue_size_);
+  }
+}
+
+void PointCloudToLaserPointCloudNodelet::disconnectCb()
+{
+  boost::mutex::scoped_lock lock(connect_mutex_);
+  if (pub_.getNumSubscribers() == 0)
+  {
+    NODELET_INFO("No subscibers to scan, shutting down subscriber to pointcloud");
+    sub_.unsubscribe();
+  }
+}
+
+void PointCloudToLaserPointCloudNodelet::failureCb(const sensor_msgs::PointCloud2ConstPtr& cloud_msg,
+                                             tf2_ros::filter_failure_reasons::FilterFailureReason reason)
+{
+  NODELET_WARN_STREAM_THROTTLE(1.0, "Can't transform pointcloud from frame " << cloud_msg->header.frame_id << " to "
+                                                                             << message_filter_->getTargetFramesString()
+                                                                             << " at time " << cloud_msg->header.stamp
+                                                                             << ", reason: " << reason);
+}
+
+void PointCloudToLaserPointCloudNodelet::cloudCb(const sensor_msgs::PointCloud2ConstPtr& cloud_msg)
+{
+  // build laserscan laser_output using the same frame as the original cloud
+  sensor_msgs::LaserScan laser_output;
+  laser_output.header = cloud_msg->header;
+  laser_output.angle_min = angle_min_;
+  laser_output.angle_max = angle_max_;
+  laser_output.angle_increment = angle_increment_;
+  laser_output.time_increment = 0.0;
+  laser_output.scan_time = scan_time_;
+  laser_output.range_min = range_min_;
+  laser_output.range_max = range_max_;
+
+  // determine amount of rays to create
+  uint32_t ranges_size = std::ceil((laser_output.angle_max - laser_output.angle_min) / laser_output.angle_increment);
+
+  // determine if laserscan rays with no obstacle data will evaluate to infinity or max_range
+  if (use_inf_)
+  {
+    laser_output.ranges.assign(ranges_size, std::numeric_limits<double>::infinity());
+  }
+  else
+  {
+    laser_output.ranges.assign(ranges_size, laser_output.range_max + inf_epsilon_);
+  }
+  laser_output.intensities.assign(ranges_size, 0);
+
+  sensor_msgs::PointCloud2ConstPtr cloud_out;
+  cloud_out = cloud_msg;
+
+  // Iterate through pointcloud
+  for (sensor_msgs::PointCloud2ConstIterator<float> iter_x(*cloud_out, "x"), iter_y(*cloud_out, "y"),
+       iter_z(*cloud_out, "z"); //, iter_i(*cloud_out, "intensity");
+       iter_x != iter_x.end(); ++iter_x, ++iter_y, ++iter_z/*, ++iter_i*/)
+  {
+    if (std::isnan(*iter_x) || std::isnan(*iter_y) || std::isnan(*iter_z))
+    {
+      NODELET_DEBUG("rejected for nan in point(%f, %f, %f)\n", *iter_x, *iter_y, *iter_z);
+      continue;
+    }
+
+    if (*iter_z > max_height_ || *iter_z < min_height_)
+    {
+      NODELET_DEBUG("rejected for height %f not in range (%f, %f)\n", *iter_z, min_height_, max_height_);
+      continue;
+    }
+
+    double range = hypot(*iter_x, *iter_y);
+    if (range < range_min_)
+    {
+      NODELET_DEBUG("rejected for range %f below minimum value %f. Point: (%f, %f, %f)", range, range_min_, *iter_x,
+                    *iter_y, *iter_z);
+      continue;
+    }
+    if (range > range_max_)
+    {
+      NODELET_DEBUG("rejected for range %f above maximum value %f. Point: (%f, %f, %f)", range, range_max_, *iter_x,
+                    *iter_y, *iter_z);
+      continue;
+    }
+
+    double angle = atan2(*iter_y, *iter_x);
+    if (angle < laser_output.angle_min || angle > laser_output.angle_max)
+    {
+      NODELET_DEBUG("rejected for angle %f not in range (%f, %f)\n", angle, laser_output.angle_min, laser_output.angle_max);
+      continue;
+    }
+
+    double intensity = 0; //*iter_i;
+    // overwrite range at laserscan ray if new range is smaller
+    int index = (angle - laser_output.angle_min) / laser_output.angle_increment;
+    if (range < laser_output.ranges[index] and intensity >= min_intensity_)
+    {
+      laser_output.ranges[index] = range;
+      laser_output.intensities[index] = intensity;
+    }
+  }
+
+  // Transform again to pointcloud and change the frame_id
+
+  sensor_msgs::PointCloud2Ptr scan_cloud;
+  scan_cloud.reset(new sensor_msgs::PointCloud2);
+  projector_.projectLaser(laser_output, *scan_cloud);
+
+  // Transform cloud if necessary
+  if (!target_frame_.empty() && scan_cloud->header.frame_id != target_frame_)
+  {
+    try
+    {
+      *scan_cloud = tf2_->transform(*scan_cloud, target_frame_);
+    }
+    catch (tf2::TransformException& ex)
+    {
+      NODELET_ERROR_STREAM("Transform failure: " << ex.what());
+      return;
+    }
+  }
+  pub_.publish(*scan_cloud);
+}
+}  // namespace pointcloud_to_laserscan
+
+PLUGINLIB_EXPORT_CLASS(pointcloud_to_laserscan::PointCloudToLaserPointCloudNodelet, nodelet::Nodelet)


### PR DESCRIPTION
Add node that takes PointCloud2 messages as an input and publishes another PointCloud2. The process is similar to the one done in pointcloud_to_laserscan, followed by the one in laserscan_to_pointcloud. 

The goal of this PR is offering a way to publish laser-like sensor readings in a different reference frame without losing information. pointcloud_to_laserscan offers the target_frame parameter to do this, but LaserScan readings are defined by origin and angle increments, which means that some information will be lost if we move the frame in front of the original one. Opening the LaserScan angle range could mitigate this, but invalid measurements are included for out-of-range readings, and they are indistinguishable from max_range readings.

The new pointcloud_to_laserpointcloud node publishes the resulting laser scan encapsulated in a PointCloud2 to avoid losing any information.