### PR TITLE
feat: add parameter to rename intensity field

### DIFF
--- a/include/pointcloud_to_laserscan/pointcloud_to_laserscan_nodelet.h
+++ b/include/pointcloud_to_laserscan/pointcloud_to_laserscan_nodelet.h
@@ -91,6 +91,7 @@ private:
          min_intensity_;
   bool use_inf_;
   double inf_epsilon_;
+  std::string intensity_field_name_;
 };
 
 }  // namespace pointcloud_to_laserscan

--- a/src/pointcloud_to_laserscan_nodelet.cpp
+++ b/src/pointcloud_to_laserscan_nodelet.cpp
@@ -70,6 +70,7 @@ void PointCloudToLaserScanNodelet::onInit()
   private_nh_.param<double>("range_max", range_max_, std::numeric_limits<double>::max());
   private_nh_.param<double>("inf_epsilon", inf_epsilon_, 1.0);
 
+  private_nh_.param<std::string>("intensity_field_name", intensity_field_name_, "intensity");
   private_nh_.param<double>("min_intensity", min_intensity_, 0.0);
 
   int concurrency_level;
@@ -200,7 +201,7 @@ void PointCloudToLaserScanNodelet::cloudCb(const sensor_msgs::PointCloud2ConstPt
 
   // Iterate through pointcloud
   for (sensor_msgs::PointCloud2ConstIterator<float> iter_x(*cloud_out, "x"), iter_y(*cloud_out, "y"),
-       iter_z(*cloud_out, "z"), iter_i(*cloud_out, "intensity");
+       iter_z(*cloud_out, "z"), iter_i(*cloud_out, intensity_field_name_);
        iter_x != iter_x.end(); ++iter_x, ++iter_y, ++iter_z, ++iter_i)
   {
     if (std::isnan(*iter_x) || std::isnan(*iter_y) || std::isnan(*iter_z))


### PR DESCRIPTION
This pull request adds support for configurable intensity field names in the `PointCloudToLaserScanNodelet`. This allows users to specify which field in the point cloud message should be used for intensity, increasing flexibility for different sensor outputs.

**Configurability improvements:**

* Added a new parameter `intensity_field_name` (defaulting to `"intensity"`) in the nodelet's parameters, allowing users to specify the field name for intensity values. [[1]](diffhunk://#diff-71c0dd4a539f3ceae2905705caf60720ee037c2c38504bc4a8e2129216b96b1dR73) [[2]](diffhunk://#diff-2179253a3384485375049845e5ac03ea6631a1cc78e597121285a59db7723ac1R94)
* Updated the point cloud iteration logic to use the configurable `intensity_field_name` instead of hardcoding `"intensity"`, enabling compatibility with point clouds that use different field names.