### PR TITLE
fix: intensities error

### DIFF
--- a/include/pointcloud_to_laserscan/pointcloud_to_laserscan_nodelet.h
+++ b/include/pointcloud_to_laserscan/pointcloud_to_laserscan_nodelet.h
@@ -85,7 +85,7 @@ private:
 
   // ROS Parameters
   unsigned int input_queue_size_;
-  std::string target_frame_;
+    std::string target_frame_, intensity_field_name_;
   double tolerance_;
   double min_height_, max_height_, angle_min_, angle_max_, angle_increment_, scan_time_, range_min_, range_max_,
          min_intensity_;

--- a/include/pointcloud_to_laserscan/pointcloud_to_laserscan_nodelet.h
+++ b/include/pointcloud_to_laserscan/pointcloud_to_laserscan_nodelet.h
@@ -87,7 +87,8 @@ private:
   unsigned int input_queue_size_;
   std::string target_frame_;
   double tolerance_;
-  double min_height_, max_height_, angle_min_, angle_max_, angle_increment_, scan_time_, range_min_, range_max_, min_intensity_;
+  double min_height_, max_height_, angle_min_, angle_max_, angle_increment_, scan_time_, range_min_, range_max_,
+         min_intensity_;
   bool use_inf_;
   double inf_epsilon_;
 };

--- a/src/pointcloud_to_laserscan_nodelet.cpp
+++ b/src/pointcloud_to_laserscan_nodelet.cpp
@@ -239,7 +239,7 @@ void PointCloudToLaserScanNodelet::cloudCb(const sensor_msgs::PointCloud2ConstPt
     double intensity = *iter_i;
     // overwrite range at laserscan ray if new range is smaller
     int index = (angle - output.angle_min) / output.angle_increment;
-    if (range < output.ranges[index] and intensity >= min_intensity_)
+    if (range < output.ranges[index] && intensity >= min_intensity_)
     {
       output.ranges[index] = range;
       output.intensities[index] = intensity;

--- a/src/pointcloud_to_laserscan_nodelet.cpp
+++ b/src/pointcloud_to_laserscan_nodelet.cpp
@@ -42,12 +42,29 @@
 #include <pluginlib/class_list_macros.h>
 #include <pointcloud_to_laserscan/pointcloud_to_laserscan_nodelet.h>
 #include <sensor_msgs/LaserScan.h>
+#include <sensor_msgs/PointField.h>
 #include <sensor_msgs/point_cloud2_iterator.h>
 #include <string>
 #include <tf2_sensor_msgs/tf2_sensor_msgs.h>
 
 namespace pointcloud_to_laserscan
 {
+namespace
+{
+bool hasField(const sensor_msgs::PointCloud2& cloud, const std::string& field_name)
+{
+  for (std::vector<sensor_msgs::PointField>::const_iterator field = cloud.fields.begin(); field != cloud.fields.end();
+       ++field)
+  {
+    if (field->name == field_name)
+    {
+      return true;
+    }
+  }
+  return false;
+}
+}  // namespace
+
 PointCloudToLaserScanNodelet::PointCloudToLaserScanNodelet()
 {
 }
@@ -71,6 +88,7 @@ void PointCloudToLaserScanNodelet::onInit()
   private_nh_.param<double>("inf_epsilon", inf_epsilon_, 1.0);
 
   private_nh_.param<double>("min_intensity", min_intensity_, 0.0);
+  private_nh_.param<std::string>("intensity_field_name", intensity_field_name_, "intensity");
 
   int concurrency_level;
   private_nh_.param<int>("concurrency_level", concurrency_level, 1);
@@ -198,51 +216,110 @@ void PointCloudToLaserScanNodelet::cloudCb(const sensor_msgs::PointCloud2ConstPt
     cloud_out = cloud_msg;
   }
 
-  // Iterate through pointcloud
-  for (sensor_msgs::PointCloud2ConstIterator<float> iter_x(*cloud_out, "x"), iter_y(*cloud_out, "y"),
-       iter_z(*cloud_out, "z"), iter_i(*cloud_out, "intensity");
-       iter_x != iter_x.end(); ++iter_x, ++iter_y, ++iter_z, ++iter_i)
+  const bool has_intensity_field = hasField(*cloud_out, intensity_field_name_);
+  if (!has_intensity_field)
   {
-    if (std::isnan(*iter_x) || std::isnan(*iter_y) || std::isnan(*iter_z))
-    {
-      NODELET_DEBUG("rejected for nan in point(%f, %f, %f)\n", *iter_x, *iter_y, *iter_z);
-      continue;
-    }
+    NODELET_WARN_STREAM_THROTTLE(5.0, "PointCloud field '" << intensity_field_name_
+                                                            << "' not found. Using 0.0 intensity values.");
+  }
 
-    if (*iter_z > max_height_ || *iter_z < min_height_)
-    {
-      NODELET_DEBUG("rejected for height %f not in range (%f, %f)\n", *iter_z, min_height_, max_height_);
-      continue;
-    }
+  // Iterate through pointcloud
+  sensor_msgs::PointCloud2ConstIterator<float> iter_x(*cloud_out, "x"), iter_y(*cloud_out, "y"),
+      iter_z(*cloud_out, "z");
 
-    double range = hypot(*iter_x, *iter_y);
-    if (range < range_min_)
+  if (has_intensity_field)
+  {
+    sensor_msgs::PointCloud2ConstIterator<float> iter_i(*cloud_out, intensity_field_name_);
+    for (; iter_x != iter_x.end(); ++iter_x, ++iter_y, ++iter_z, ++iter_i)
     {
-      NODELET_DEBUG("rejected for range %f below minimum value %f. Point: (%f, %f, %f)", range, range_min_, *iter_x,
-                    *iter_y, *iter_z);
-      continue;
-    }
-    if (range > range_max_)
-    {
-      NODELET_DEBUG("rejected for range %f above maximum value %f. Point: (%f, %f, %f)", range, range_max_, *iter_x,
-                    *iter_y, *iter_z);
-      continue;
-    }
+      if (std::isnan(*iter_x) || std::isnan(*iter_y) || std::isnan(*iter_z))
+      {
+        NODELET_DEBUG("rejected for nan in point(%f, %f, %f)\n", *iter_x, *iter_y, *iter_z);
+        continue;
+      }
 
-    double angle = atan2(*iter_y, *iter_x);
-    if (angle < output.angle_min || angle > output.angle_max)
-    {
-      NODELET_DEBUG("rejected for angle %f not in range (%f, %f)\n", angle, output.angle_min, output.angle_max);
-      continue;
-    }
+      if (*iter_z > max_height_ || *iter_z < min_height_)
+      {
+        NODELET_DEBUG("rejected for height %f not in range (%f, %f)\n", *iter_z, min_height_, max_height_);
+        continue;
+      }
 
-    double intensity = *iter_i;
-    // overwrite range at laserscan ray if new range is smaller
-    int index = (angle - output.angle_min) / output.angle_increment;
-    if (range < output.ranges[index] && intensity >= min_intensity_)
+      double range = hypot(*iter_x, *iter_y);
+      if (range < range_min_)
+      {
+        NODELET_DEBUG("rejected for range %f below minimum value %f. Point: (%f, %f, %f)", range, range_min_,
+                      *iter_x, *iter_y, *iter_z);
+        continue;
+      }
+      if (range > range_max_)
+      {
+        NODELET_DEBUG("rejected for range %f above maximum value %f. Point: (%f, %f, %f)", range, range_max_,
+                      *iter_x, *iter_y, *iter_z);
+        continue;
+      }
+
+      double angle = atan2(*iter_y, *iter_x);
+      if (angle < output.angle_min || angle > output.angle_max)
+      {
+        NODELET_DEBUG("rejected for angle %f not in range (%f, %f)\n", angle, output.angle_min, output.angle_max);
+        continue;
+      }
+
+      double intensity = *iter_i;
+      // overwrite range at laserscan ray if new range is smaller
+      int index = (angle - output.angle_min) / output.angle_increment;
+      if (range < output.ranges[index] && intensity >= min_intensity_)
+      {
+        output.ranges[index] = range;
+        output.intensities[index] = intensity;
+      }
+    }
+  }
+  else
+  {
+    for (; iter_x != iter_x.end(); ++iter_x, ++iter_y, ++iter_z)
     {
-      output.ranges[index] = range;
-      output.intensities[index] = intensity;
+      if (std::isnan(*iter_x) || std::isnan(*iter_y) || std::isnan(*iter_z))
+      {
+        NODELET_DEBUG("rejected for nan in point(%f, %f, %f)\n", *iter_x, *iter_y, *iter_z);
+        continue;
+      }
+
+      if (*iter_z > max_height_ || *iter_z < min_height_)
+      {
+        NODELET_DEBUG("rejected for height %f not in range (%f, %f)\n", *iter_z, min_height_, max_height_);
+        continue;
+      }
+
+      double range = hypot(*iter_x, *iter_y);
+      if (range < range_min_)
+      {
+        NODELET_DEBUG("rejected for range %f below minimum value %f. Point: (%f, %f, %f)", range, range_min_,
+                      *iter_x, *iter_y, *iter_z);
+        continue;
+      }
+      if (range > range_max_)
+      {
+        NODELET_DEBUG("rejected for range %f above maximum value %f. Point: (%f, %f, %f)", range, range_max_,
+                      *iter_x, *iter_y, *iter_z);
+        continue;
+      }
+
+      double angle = atan2(*iter_y, *iter_x);
+      if (angle < output.angle_min || angle > output.angle_max)
+      {
+        NODELET_DEBUG("rejected for angle %f not in range (%f, %f)\n", angle, output.angle_min, output.angle_max);
+        continue;
+      }
+
+      double intensity = 0.0;
+      // overwrite range at laserscan ray if new range is smaller
+      int index = (angle - output.angle_min) / output.angle_increment;
+      if (range < output.ranges[index] && intensity >= min_intensity_)
+      {
+        output.ranges[index] = range;
+        output.intensities[index] = intensity;
+      }
     }
   }
   pub_.publish(output);


### PR DESCRIPTION
This pull request enhances the flexibility and robustness of the `pointcloud_to_laserscan` nodelet by allowing configurable handling of the intensity field in incoming point clouds. The main improvements are the introduction of a parameter for specifying the intensity field name, safer processing when the field is missing, and clearer code structure for point cloud iteration.

### Configurable intensity field support

* Added a new ROS parameter `intensity_field_name` to allow users to specify which field in the point cloud should be used for intensity values, making the nodelet compatible with different point cloud formats. (`src/pointcloud_to_laserscan_nodelet.cpp`, `include/pointcloud_to_laserscan/pointcloud_to_laserscan_nodelet.h`) [[1]](diffhunk://#diff-71c0dd4a539f3ceae2905705caf60720ee037c2c38504bc4a8e2129216b96b1dR91) [[2]](diffhunk://#diff-2179253a3384485375049845e5ac03ea6631a1cc78e597121285a59db7723ac1L88-R91)

* Implemented a helper function `hasField` to check for the presence of the specified intensity field in the incoming point cloud, improving robustness and error handling. (`src/pointcloud_to_laserscan_nodelet.cpp`)

### Robust handling of missing intensity field

* Added logic to use a default intensity value of `0.0` and issue a warning if the specified intensity field is not found, ensuring the nodelet continues to function even with incomplete data. (`src/pointcloud_to_laserscan_nodelet.cpp`) [[1]](diffhunk://#diff-71c0dd4a539f3ceae2905705caf60720ee037c2c38504bc4a8e2129216b96b1dR219-R233) [[2]](diffhunk://#diff-71c0dd4a539f3ceae2905705caf60720ee037c2c38504bc4a8e2129216b96b1dL242-R324)

### Code clarity and maintainability

* Refactored the point cloud iteration in `cloudCb` to separate cases for when the intensity field is present and absent, improving code readability and maintainability. (`src/pointcloud_to_laserscan_nodelet.cpp`) [[1]](diffhunk://#diff-71c0dd4a539f3ceae2905705caf60720ee037c2c38504bc4a8e2129216b96b1dR219-R233) [[2]](diffhunk://#diff-71c0dd4a539f3ceae2905705caf60720ee037c2c38504bc4a8e2129216b96b1dL242-R324)

* Minor formatting improvements for debug messages to enhance log clarity. (`src/pointcloud_to_laserscan_nodelet.cpp`)